### PR TITLE
Fix linking on Linux. Replace gzip.load with gzip.load_from_bytes.

### DIFF
--- a/http/http_client.odin
+++ b/http/http_client.odin
@@ -528,8 +528,8 @@ handle_protocol :: proc(sess: ^Session, sock: Socket, req: ^Request) -> (
 				defer bytes.buffer_destroy(&decompressed)
 				switch compression {
 				case "gzip":
-					err := gzip.load(
-						slice = compressed_buffer,
+					err := gzip.load_from_bytes(
+						data = compressed_buffer,
 						buf = &decompressed,
 						known_gzip_size = len(compressed_buffer),
 					)

--- a/http/ssl.odin
+++ b/http/ssl.odin
@@ -10,8 +10,11 @@ when ODIN_OS == .Windows && SSL_SUPPORT {
 	foreign import libcrypto "../lib/libcrypto.lib"
 	foreign import libssl "../lib/libssl.lib"
 } else when SSL_SUPPORT {
-	foreign import libcrypto "system:libcrypto"
-	foreign import libssl "system:libssl"
+	@(require)
+	foreign import libdl "system:dl"
+	@(require)
+	foreign import libcrypto "system:crypto"
+	foreign import libssl "system:ssl"
 }
 
 SSL_METHOD :: distinct rawptr


### PR DESCRIPTION
Make linking work on Linux by requiring libcrypto and libdl.
Replace gzip.load, which appears to have been removed﻿, with gzip.load_from_bytes.
